### PR TITLE
typo fixes

### DIFF
--- a/lib/MojoX/Log/Log4perl.pm
+++ b/lib/MojoX/Log/Log4perl.pm
@@ -195,7 +195,7 @@ If you don't give it any arguments, the following default configuration is set:
 
 =head2 new( $config, $delay )
 
-As as optional second argument to C<new()>, you can set a delay in seconds that will be passed directly to Log::Log4perl::init_and_watch. This makes Log4perl check every C<$delay> seconds for changes in the configuration file, and reload it if the file modification time is different.
+As optional second argument to C<new()>, you can set a delay in seconds that will be passed directly to Log::Log4perl::init_and_watch. This makes Log4perl check every C<$delay> seconds for changes in the configuration file, and reload it if the file modification time is different.
 
 You can also define a signal to watch and Log4perl will setup a signal handler to check the configuration file again only when that particular signal is received by the application, for example via the C<kill> command:
 
@@ -379,7 +379,7 @@ L<http://search.cpan.org/dist/MojoX-Log-Log4perl/>
 
 =head1 ACKNOWLEDGEMENTS
 
-This module was heavilly inspired by L<< Catalyst::Log::Log4perl >>. A lot of the documentation and specifications were taken almost verbatim from it.
+This module was heavily inspired by L<< Catalyst::Log::Log4perl >>. A lot of the documentation and specifications were taken almost verbatim from it.
 
 Also, this is just a minor work. Credit is really due to Michael Schilli and Sebastian Riedel, creators and maintainers of L<< Log::Log4perl >> and L<< Mojo >>, respectively.
 


### PR DESCRIPTION
Not exactly sure if the double as was just meant to be an "as" or if on of them was meant to be another word.
